### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,12 +71,12 @@ const logfmt = (level, message, fields = {}) => {
         // Properly format different value types
         if (typeof value === 'string') {
             // Escape quotes in strings
-            logEntry += ` ${key}="${value.replace(/"/g, '\\"')}"`;
+            logEntry += ` ${key}="${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
         } else if (value instanceof Error) {
             // Extract error details
-            logEntry += ` ${key}="${value.message.replace(/"/g, '\\"')}"`;
+            logEntry += ` ${key}="${value.message.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
             if (value.stack) {
-                logEntry += ` ${key}_stack="${value.stack.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`;
+                logEntry += ` ${key}_stack="${value.stack.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`;
             }
         } else if (value === null || value === undefined) {
             logEntry += ` ${key}=null`;


### PR DESCRIPTION
Potential fix for [https://github.com/sagniKdas53/temp-monitor-api/security/code-scanning/1](https://github.com/sagniKdas53/temp-monitor-api/security/code-scanning/1)

To fix the problem, we need to ensure that backslashes are also escaped in the input strings. This can be achieved by first replacing backslashes with double backslashes and then replacing double quotes with escaped double quotes. This ensures that both backslashes and double quotes are properly escaped.

The best way to fix the problem without changing existing functionality is to update the `logfmt` function to include an additional `replace` call to handle backslashes. Specifically, we will modify the lines where `value.replace` is used to first escape backslashes before escaping double quotes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
